### PR TITLE
Fix operator to strip templates from workload list

### DIFF
--- a/WAFR-Central.yaml
+++ b/WAFR-Central.yaml
@@ -93,7 +93,7 @@ Resources:
       Runtime: python3.9
       Layers:
         - !Ref LambdaLayerDecorators
-      Timeout: 60
+      Timeout: 180
       Environment:
         Variables:
           MODE: !Ref UpdateMode
@@ -114,7 +114,7 @@ Resources:
       Runtime: python3.9
       Layers:
         - !Ref LambdaLayerDecorators
-      Timeout: 5
+      Timeout: 10
       Environment:
         Variables:
           TEMPLATE_PREFIX: !Ref TemplatePrefix

--- a/WAFR-GetWorkloadIDs/lambda_function.py
+++ b/WAFR-GetWorkloadIDs/lambda_function.py
@@ -36,7 +36,7 @@ def getWorkloadIDs():
 def stripCentralTemplate(workloadIDs):
     logger.debug(workloadIDs)
     templatePrefix = os.environ.get('TEMPLATE_PREFIX', 'CentralTemplate')
-    res = [i for i in workloadIDs if not (i['WorkloadName'] == templatePrefix)]
+    res = [i for i in workloadIDs if not (templatePrefix in i['WorkloadName'] )]
     return (res)
 
 


### PR DESCRIPTION
*Issue #, if available:*
#1 

*Description of changes:*
Correctly check for CentralTemplate in the workload ID name rather than check for an exact match.
Also increased the timeout for the update answers and get workloads lambda functions after timeouts with multiple templates during testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
